### PR TITLE
Fix regexp for Access Mode and rule path

### DIFF
--- a/apparmor-mode.el
+++ b/apparmor-mode.el
@@ -126,7 +126,7 @@
 
 (defvar apparmor-mode-profile-name-regexp "[[:alnum:]]+")
 
-(defvar apparmor-mode-profile-attachment-regexp "[[:alnum:]*@/_{},-]+")
+(defvar apparmor-mode-profile-attachment-regexp "[][[:alnum:]*@/_{},-.?]+")
 
 (defvar apparmor-mode-profile-flags-regexp
   (concat  "\\(flags\\)=(\\(" (regexp-opt apparmor-mode-profile-flags) "\\s-*\\)*)") )
@@ -136,7 +136,7 @@
 
 (defvar apparmor-mode-file-rule-regexp
   (concat "^\\s-*\\(\\(audit\\|owner\\|deny\\)\\s-+\\)*"
-          "\\(" apparmor-mode-profile-attachment-regexp "\\)\\s-+\\([CPUacilmpruwx]+\\)\\s-*"
+          "\\(" apparmor-mode-profile-attachment-regexp "\\)\\s-+\\([CPUaciklmpruwx]+\\)\\s-*"
           "\\(->\\s-+\\(" apparmor-mode-profile-attachment-regexp "\\)\\)?\\s-*"
           ","))
 


### PR DESCRIPTION
According to `man apparmor.d`, `Access Mode` should add `k`:

```
Access Modes
       m       - allow PROT_EXEC with mmap(2) calls
       l       - link
       k       - lock
```
and brackets `[]` are commonly used as RegExp in file path matching of rules.

The following examples are from the default profiles of openSUSE:

![a](https://github.com/alexmurray/apparmor-mode/assets/1370070/1d5b353d-9eaa-4be6-93b6-2de4b251e0fa)
![b](https://github.com/alexmurray/apparmor-mode/assets/1370070/f169a3da-0d56-4180-90aa-8057d7b0e67b)
![c](https://github.com/alexmurray/apparmor-mode/assets/1370070/c538afe3-6ff9-4b3f-afbe-2efe752f3183)
